### PR TITLE
WIP: Add: Better icons

### DIFF
--- a/custom_components/atrea/climate.py
+++ b/custom_components/atrea/climate.py
@@ -96,7 +96,7 @@ class AtreaDevice(ClimateEntity):
         self._current_preset = None
         self._current_hvac_mode = None
         self._unit = "Status"
-        self._icon = "mdi:alert-decagram"
+        self._icon = 'mdi:fan'
         self.air_handling_control = None
 
         for required_preset in preset_list:
@@ -116,6 +116,17 @@ class AtreaDevice(ClimateEntity):
 
     @property
     def icon(self):
+        if self._alerts:
+            self._icon = 'mdi:alert-decagram'
+        elif self._warnings:
+            self._icon = 'mdi:fan-alert'
+        elif self._current_hvac_mode == HVAC_MODE_OFF:
+            self._icon = 'mdi:fan-off'
+        elif self._current_preset == 4:
+            self._icon = 'mdi:cached'
+        else:
+            self._icon = 'mdi:fan'
+
         return self._icon
 
     @property


### PR DESCRIPTION
I was constantly worried there is something wrong with my unit when seeing alert
icon in Lovelace :)

This commit change default icon to "fan", which is IMHO better for circulation
unit.

It also display different icons for different states. This is first try with
hacky implementation. Currently (first match wins):

- alert icon if there are some alerts
- fan with exclamation point for warnings
- striked when state is off
- arrows in circle for recirculation
- fan

This is just concept (or better this is how I hacked it in my environment and testing visually now) - I just wanted to know if you plan to support something like this and what are your ideas. I suppose there should be better way to check for states and get their relevant icons. Not sure about custom preresets (we can use fan-1 fan-2 and fan-3) etc. For now I just added icons for states I'm using now and want visible.