### PR TITLE
Update climate.py

### DIFF
--- a/custom_components/atrea/climate.py
+++ b/custom_components/atrea/climate.py
@@ -238,10 +238,10 @@ class AtreaDevice(ClimateEntity):
         self._alerts = []
         if(status != False):
             if('I10202' in status):
-                if(float(status['I10202']) > 6550):
-                    self._outside_temp = (float(status['I10202'])-6550)/10 * -1
+                if(float(status['I10211']) > 1300):
+                    self._outside_temp = round(((50-(float(status['I10211'])-65036)/10)*-1),1)
                 else:
-                    self._outside_temp = float(status['I10202'])/10
+                    self._outside_temp = float(status['I10211'])/10
             elif('I00202' in status):
                 if(self.atrea.getValue('I00202') == 126.0):
                     if(self.atrea.getValue('H00511') == 1):


### PR DESCRIPTION
Changed the negative temperature computation according to the modbus documentation [ 65036 ~ -50,0°C ..65535 ~ -0,1°C, 1..1300 ~ 0,1..130,0°C ] as the original implementation has been throwing values around -5.900 C into HA.

Also changed register I10202 (Input TEa) to register I10211 (T-ODA) according to the Modbus parameters. T-ODA is always the temperature of the incoming outside air according to the setting in the service menu (it is generally TEa, but depends on the orientation of the unit and can also be set externally through modbus) - possibly not necessary.

As of today 20.3.2021 temperatures have been low enough and I have confirmed that the proposed change to the code works as intented for my unit with ECV380. RD5.CF and latest available software :) 