### PR TITLE
Use index I10212 for supply temp

### DIFF
--- a/custom_components/atrea/climate.py
+++ b/custom_components/atrea/climate.py
@@ -323,8 +323,8 @@ class AtreaDevice(ClimateEntity):
             elif "I00210" in status:
                 self._inside_temp = self.atrea.getValue("I00210")
 
-            if "I10200" in status:
-                self._supply_air_temp = float(status["I10200"]) / 10
+            if "I10212" in status:
+                self._supply_air_temp = float(status["I10212"]) / 10
             elif "I00200" in status:
                 self._supply_air_temp = self.atrea.getValue("I00200")
 


### PR DESCRIPTION
According to the Modbus specification of RD5 supply air temperature has index I10212.