### PR TITLE
Expose SA1 output and IN1 input

### DIFF
--- a/custom_components/atrea/climate.py
+++ b/custom_components/atrea/climate.py
@@ -96,6 +96,8 @@ class AtreaDevice(ClimateEntity):
         self._active_inputs = []
         self._forced_mode = None
         self._current_power = None
+        self._in1 = None
+        self._sa1 = None
 
         self._current_preset = None
         self._current_hvac_mode = None
@@ -212,6 +214,8 @@ class AtreaDevice(ClimateEntity):
         attributes["active_inputs"] = self._active_inputs
         attributes["forced_mode"] = self._forced_mode.name
         attributes["current_power"] = self._current_power
+        attributes["in1"] = self._in1
+        attributes["sa1"] = self._sa1
 
         if self._heating == 1:
             attributes["hvac_action"] = HVACAction.HEATING
@@ -358,6 +362,18 @@ class AtreaDevice(ClimateEntity):
                 self._cooling = int(status["C10216"])
             else:
                 self._cooling = -1
+
+            # Input IN1
+            if "I10205" in status:
+                self._in1 = int(status["I10205"])
+            else:
+                self._in1 = -1
+
+            # Output SA1
+            if "H10202" in status:
+                self._sa1 = int(status["H10202"])
+            else:
+                self._sa1 = -1
 
             # D1..D4 inputs are reported in D10200..D10203
             for inpt in range(4):

--- a/custom_components/atrea/climate.py
+++ b/custom_components/atrea/climate.py
@@ -214,8 +214,11 @@ class AtreaDevice(ClimateEntity):
         attributes["active_inputs"] = self._active_inputs
         attributes["forced_mode"] = self._forced_mode.name
         attributes["current_power"] = self._current_power
-        attributes["in1"] = self._in1
-        attributes["sa1"] = self._sa1
+
+        if self._in1 not None:
+            attributes["in1"] = self._in1
+        if self._sa1 not None:
+            attributes["sa1"] = self._sa1
 
         if self._heating == 1:
             attributes["hvac_action"] = HVACAction.HEATING
@@ -366,14 +369,10 @@ class AtreaDevice(ClimateEntity):
             # Input IN1
             if "I10205" in status:
                 self._in1 = int(status["I10205"])
-            else:
-                self._in1 = -1
 
             # Output SA1
             if "H10202" in status:
                 self._sa1 = int(status["H10202"])
-            else:
-                self._sa1 = -1
 
             # D1..D4 inputs are reported in D10200..D10203
             for inpt in range(4):


### PR DESCRIPTION
Expose SA1 output which can monitor e.g. pre-heater.
Expose IN1 input which can monitor e.g. CO2 sensor.

Here are examples from sensors.yaml how to interpret numbers from SA1 and IN1:

```
atrea_in1:
      friendly_name: 'CO2'
      unit_of_measurement: 'ppm'
      # CO2
      # https://www.cidla.cz/data/pdf/CZ/UM/um-ADS-CO2-24-cz.pdf
      # 2V - 0-400ppm
      # 10V - 2000ppm
      # input/1000 to get voltage
      value_template: >-
        {{ state_attr('climate.atrea', 'in1')/1000*2000/10 | float | round(0) | int }}
atrea_sa1:
      friendly_name: 'Preheating'
      unit_of_measurement: '%'
      value_template: >-
        {{ state_attr('climate.atrea', 'sa1')*10 | round(0) | int }}
```