### PR TITLE
fix: OptionsFlow self.config_entry assignment removed (HA 2025.12+)

### DIFF
--- a/custom_components/atrea/config_flow.py
+++ b/custom_components/atrea/config_flow.py
@@ -157,7 +157,8 @@ class FlowHandler(config_entries.ConfigFlow):
 
 class AtreaOptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, config_entry):
-        self.config_entry = config_entry
+        #haze 500 - HA 2024.11+ read only atribut
+        #self.config_entry = config_entry
         self.options = dict(config_entry.options)
 
     async def async_step_init(self, user_input=None):


### PR DESCRIPTION
Replaces #33 — that PR was auto-closed after I force-pushed to my fork (email cleanup via `git filter-repo`), the original head commit no longer existed. Fresh branch from upstream master with the same single-line fix, so it has clean shared history with this repo.

## Problem

HA 2024.11+ deprecated and HA **2025.12+ enforces** `config_entry` as a read-only property on `OptionsFlow`. Subclasses that assign `self.config_entry = config_entry` in their `__init__` now hit:

```
AttributeError: can't set attribute 'config_entry'
```

This causes the **Configure** dialog of the Atrea integration to return HTTP 500 in recent HA versions.

## Fix

Remove the explicit assignment from `AtreaOptionsFlowHandler.__init__`. `config_entry` is still accessible via the parent class property, so the rest of the OptionsFlow logic is unchanged.

## Reference

- HA dev blog 2024.11: https://developers.home-assistant.io/blog/2024/11/12/options-flow/
- HA core PR enforcing the change in 2025.12

## Verified

- Custom_component loads without errors on HA 2026.5+
- Configure dialog opens correctly, all preset toggles & fan_modes input work as before